### PR TITLE
Fix/1.20.6 closes #61

### DIFF
--- a/src/main/java/org/adde0109/ambassador/Ambassador.java
+++ b/src/main/java/org/adde0109/ambassador/Ambassador.java
@@ -40,6 +40,9 @@ import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_19;
+import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_19_1;
+import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_19_3;
+import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_20_3;
 import static com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentIdentifier.mapSet;
 
 @Plugin(id = "ambassador", name = "Ambassador", version = "1.4.4", authors = {"adde0109"})
@@ -134,8 +137,8 @@ public class Ambassador {
 
     Method argumentRegistry = ArgumentPropertyRegistry.class.getDeclaredMethod("register", ArgumentIdentifier.class, Class.class, ArgumentPropertySerializer.class);
     argumentRegistry.setAccessible(true);
-    argumentRegistry.invoke(null,ArgumentIdentifier.id("forge:enum", mapSet(MINECRAFT_1_19, 50)), EnumArgumentProperty.class, EnumArgumentPropertySerializer.ENUM);
-    argumentRegistry.invoke(null,ArgumentIdentifier.id("forge:modid", mapSet(MINECRAFT_1_19, 51)), ModIdArgumentProperty.class,
+    argumentRegistry.invoke(null,ArgumentIdentifier.id("forge:enum", mapSet(MINECRAFT_1_19, -255)), EnumArgumentProperty.class, EnumArgumentPropertySerializer.ENUM);
+    argumentRegistry.invoke(null,ArgumentIdentifier.id("forge:modid", mapSet(MINECRAFT_1_19, -254)), ModIdArgumentProperty.class,
             new ArgumentPropertySerializer<>() {
               @Override
               public ModIdArgumentProperty deserialize(ByteBuf buf, ProtocolVersion protocolVersion) {

--- a/src/main/java/org/adde0109/ambassador/Ambassador.java
+++ b/src/main/java/org/adde0109/ambassador/Ambassador.java
@@ -18,9 +18,7 @@ import java.util.Map;
 
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.proxy.VelocityServer;
-import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.network.ConnectionManager;
-import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentIdentifier;
 import com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentPropertyRegistry;
 import com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentPropertySerializer;
@@ -40,9 +38,6 @@ import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_19;
-import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_19_1;
-import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_19_3;
-import static com.velocitypowered.api.network.ProtocolVersion.MINECRAFT_1_20_3;
 import static com.velocitypowered.proxy.protocol.packet.brigadier.ArgumentIdentifier.mapSet;
 
 @Plugin(id = "ambassador", name = "Ambassador", version = "1.4.4", authors = {"adde0109"})


### PR DESCRIPTION
Updates the argument registry so that Ambassador no longer collides with the new ids added in MC 1.20.5.
Previously this was causing user disconnects if they had a multi-version setup with their proxy, and had a user opp'ed for versions 1.20.5+.
This can also probably be cherry picked to Ambassador v1.5.

With some inspiration from a user's patch (which fixed the issue, but not the root cause)
https://github.com/adde0109/Ambassador/compare/v1.4.4...Mac898:Ambassador:patch-bypass-argument-id-issue

My implementation:
```diff
- argumentRegistry.invoke(null,ArgumentIdentifier.id("forge:enum", mapSet(MINECRAFT_1_19, 50)), EnumArgumentProperty.class, EnumArgumentPropertySerializer.ENUM);
- argumentRegistry.invoke(null,ArgumentIdentifier.id("forge:modid", mapSet(MINECRAFT_1_19, 51)), ModIdArgumentProperty.class,
+ argumentRegistry.invoke(null,ArgumentIdentifier.id("forge:enum", mapSet(MINECRAFT_1_19, -255)), EnumArgumentProperty.class, EnumArgumentPropertySerializer.ENUM);
+ argumentRegistry.invoke(null,ArgumentIdentifier.id("forge:modid", mapSet(MINECRAFT_1_19, -254)), ModIdArgumentProperty.class,
```
The ids were [bumped up past 49 in 1.20.5](<https://github.com/PaperMC/Velocity/blob/4aa9ee77351531430019b4725427c5d9e5bed913/proxy/src/main/java/com/velocitypowered/proxy/protocol/packet/brigadier/ArgumentPropertyRegistry.java#L265>), which then makes it so you run into this issue on newer servers.
Cross-stitch was labeled as `-256`, so I thought I'd follow suit and update Ambassador's registered arguments to be on the far end as well.